### PR TITLE
consoles: Make DirectoryRoleBinding optional

### DIFF
--- a/cmd/workloads-manager/main.go
+++ b/cmd/workloads-manager/main.go
@@ -24,14 +24,15 @@ import (
 var (
 	scheme = runtime.NewScheme()
 
-	app                    = kingpin.New("workloads-manager", "Manages workloads.crd.gocardless.com resources").Version(cmd.VersionStanza())
-	contextName            = app.Flag("context-name", "Distinct name for the context this controller runs within. Usually the user-facing name of the kubernetes context for the cluster").Envar("CONTEXT_NAME").String()
-	pubsubProjectId        = app.Flag("pubsub-project-id", "ID for the project containing the Pub/Sub topic for console event publishing").Envar("PUBSUB_PROJECT_ID").String()
-	pubsubTopicId          = app.Flag("pubsub-topic-id", "ID of the topic to publish lifecycle event messages").Envar("PUBSUB_TOPIC_ID").String()
-	enableSessionRecording = app.Flag("session-recording", "Enable session recording features").Envar("ENABLE_SESSION_RECORDING").Default("false").Bool()
-	sessionSidecarImage    = app.Flag("session-sidecar-image", "Container image to use for the session recording sidecar container").Envar("SESSION_SIDECAR_IMAGE").Default("").String()
-	sessionPubsubProjectId = app.Flag("session-pubsub-project-id", "ID for the project containing the Pub/Sub topic for session recording").Envar("SESSION_PUBSUB_PROJECT_ID").Default("").String()
-	sessionPubsubTopicId   = app.Flag("session-pubsub-topic-id", "ID of the topic to publish session recording data to").Envar("SESSION_PUBSUB_TOPIC_ID").Default("").String()
+	app                        = kingpin.New("workloads-manager", "Manages workloads.crd.gocardless.com resources").Version(cmd.VersionStanza())
+	contextName                = app.Flag("context-name", "Distinct name for the context this controller runs within. Usually the user-facing name of the kubernetes context for the cluster").Envar("CONTEXT_NAME").String()
+	pubsubProjectId            = app.Flag("pubsub-project-id", "ID for the project containing the Pub/Sub topic for console event publishing").Envar("PUBSUB_PROJECT_ID").String()
+	pubsubTopicId              = app.Flag("pubsub-topic-id", "ID of the topic to publish lifecycle event messages").Envar("PUBSUB_TOPIC_ID").String()
+	enableDirectoryRoleBinding = app.Flag("directory-role-binding", "Use DirectoryRoleBinding for provisioning RBAC against console objects").Envar("ENABLE_DIRECTORY_ROLE_BINDING").Default("true").Bool()
+	enableSessionRecording     = app.Flag("session-recording", "Enable session recording features").Envar("ENABLE_SESSION_RECORDING").Default("false").Bool()
+	sessionSidecarImage        = app.Flag("session-sidecar-image", "Container image to use for the session recording sidecar container").Envar("SESSION_SIDECAR_IMAGE").Default("").String()
+	sessionPubsubProjectId     = app.Flag("session-pubsub-project-id", "ID for the project containing the Pub/Sub topic for session recording").Envar("SESSION_PUBSUB_PROJECT_ID").Default("").String()
+	sessionPubsubTopicId       = app.Flag("session-pubsub-topic-id", "ID of the topic to publish session recording data to").Envar("SESSION_PUBSUB_TOPIC_ID").Default("").String()
 
 	commonOpts = cmd.NewCommonOptions(app).WithMetrics(app)
 )
@@ -93,15 +94,16 @@ func main() {
 
 	// controller
 	if err = (&consolecontroller.ConsoleReconciler{
-		Client:                 mgr.GetClient(),
-		LifecycleRecorder:      lifecycleRecorder,
-		ConsoleIdBuilder:       idBuilder,
-		Log:                    ctrl.Log.WithName("controllers").WithName("console"),
-		Scheme:                 mgr.GetScheme(),
-		EnableSessionRecording: *enableSessionRecording,
-		SessionSidecarImage:    *sessionSidecarImage,
-		SessionPubsubProjectId: *sessionPubsubProjectId,
-		SessionPubsubTopicId:   *sessionPubsubTopicId,
+		Client:                     mgr.GetClient(),
+		LifecycleRecorder:          lifecycleRecorder,
+		ConsoleIdBuilder:           idBuilder,
+		Log:                        ctrl.Log.WithName("controllers").WithName("console"),
+		Scheme:                     mgr.GetScheme(),
+		EnableDirectoryRoleBinding: *enableDirectoryRoleBinding,
+		EnableSessionRecording:     *enableSessionRecording,
+		SessionSidecarImage:        *sessionSidecarImage,
+		SessionPubsubProjectId:     *sessionPubsubProjectId,
+		SessionPubsubTopicId:       *sessionPubsubTopicId,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		app.Fatalf("failed to create controller: %v", err)
 	}

--- a/config/base/managers/workloads.yaml
+++ b/config/base/managers/workloads.yaml
@@ -30,6 +30,7 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - roles
+      - rolebindings
     verbs:
       - "*"
   - apiGroups:

--- a/controllers/workloads/console/integration/suite_test.go
+++ b/controllers/workloads/console/integration/suite_test.go
@@ -99,11 +99,12 @@ var _ = BeforeSuite(func() {
 	})
 
 	err = (&consolecontroller.ConsoleReconciler{
-		Client:            mgr.GetClient(),
-		LifecycleRecorder: lifecycleRecorder,
-		Log:               ctrl.Log.WithName("controllers").WithName("console"),
-		Scheme:            mgr.GetScheme(),
-		ConsoleIdBuilder:  workloadsv1alpha1.NewConsoleIdBuilder("test"),
+		Client:                     mgr.GetClient(),
+		LifecycleRecorder:          lifecycleRecorder,
+		Log:                        ctrl.Log.WithName("controllers").WithName("console"),
+		Scheme:                     mgr.GetScheme(),
+		ConsoleIdBuilder:           workloadsv1alpha1.NewConsoleIdBuilder("test"),
+		EnableDirectoryRoleBinding: true,
 	}).SetupWithManager(context.TODO(), mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/recutil/reconcile.go
+++ b/pkg/recutil/reconcile.go
@@ -212,3 +212,23 @@ func DirectoryRoleBindingDiff(expectedObj runtime.Object, existingObj runtime.Ob
 
 	return operation
 }
+
+// RoleBindingDiff is a DiffFunc for RoleBindings
+func RoleBindingDiff(expectedObj runtime.Object, existingObj runtime.Object) Outcome {
+	expected := expectedObj.(*rbacv1.RoleBinding)
+	existing := existingObj.(*rbacv1.RoleBinding)
+
+	operation := None
+
+	if !reflect.DeepEqual(expected.Subjects, existing.Subjects) {
+		existing.Subjects = expected.Subjects
+		operation = Update
+	}
+
+	if !reflect.DeepEqual(expected.RoleRef, existing.RoleRef) {
+		existing.RoleRef = expected.RoleRef
+		operation = Update
+	}
+
+	return operation
+}


### PR DESCRIPTION
Currently, the workloads controller has a hard dependency on `DirectoryRoleBinding`s, as provided by the RBAC controller, in order to create consoles. If you try to do this, without having the RBAC controller installed, then the reconcile loop gets stuck, as the rolebinding to access the console can't be provisioned.

This is a bit presumptuous; it should be possible to run consoles without DRBs, e.g. if you just want to reference plain `User` kinds in `additionalAttachSubjects`.

This change adds a flag, which makes the usage of `DirectoryRoleBinding` optional. The flag defaults to true, meaning that this isn't a breaking change.

We intended to use this in conjunction with [Google Groups for RBAC][0] as an alternative.

[0]: https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac