### PR TITLE
Replaced more deprecated fields in Kustomization

### DIFF
--- a/config/acceptance/kustomization.yaml
+++ b/config/acceptance/kustomization.yaml
@@ -12,3 +12,26 @@ patchesStrategicMerge:
   - overlays/rbac-manager.yaml
   - overlays/vault-manager.yaml
   - overlays/workloads-manager.yaml
+
+# Sadly we must repeat the replacement as in our root Kustomization, because we've
+# overriden the image field, and there's no way to get Kustomize to run the (merged) replacements
+# after (merged) patches.
+replacements:
+  - source:
+      fieldPath: spec.template.spec.containers.[name=manager].image
+      group: apps
+      version: v1
+      kind: StatefulSet
+      name: theatre-vault-manager
+      namespace: theatre-system
+    targets:
+      - select:
+          group: apps
+          kind: StatefulSet
+          name: vault-manager
+          version: v1
+        fieldPaths:
+          - spec.template.spec.containers.0.args.0
+        options:
+          delimiter: =
+          index: 1

--- a/config/acceptance/overlays/vault-manager.yaml
+++ b/config/acceptance/overlays/vault-manager.yaml
@@ -11,9 +11,6 @@ spec:
         - name: manager
           image: theatre:latest
           imagePullPolicy: Never
-          args:
-            - --theatre-image=$(THEATRE_IMAGE)
-            - --metrics-address=0.0.0.0
           resources:
             requests:
               cpu: "100m"


### PR DESCRIPTION
Follows on from 2956e6f8e9807a8be90c9db642a86e506307b425, but do the same in `acceptance`, to fix our tests.