### PR TITLE
Fixes for usage of leader election

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,13 +74,6 @@ install-tools-homebrew:
 	brew install kubernetes-cli kustomize kind
 	echo "you also need docker and go in your developer environment"
 
-# Deprecated
-deploy:
-	kustomize build config/base | kubectl apply -f -
-
-deploy-production:
-	kustomize build config/overlays/production | kubectl apply -f -
-
 docker-build:
 	docker build -t $(IMAGE):latest .
 
@@ -92,4 +85,3 @@ docker-push:
 
 docker-tag:
 	docker tag $(IMAGE):$$(git rev-parse HEAD) $(IMAGE):latest
-

--- a/cmd/rbac-manager/main.go
+++ b/cmd/rbac-manager/main.go
@@ -73,10 +73,11 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:           scheme,
-		Metrics:          metricsserver.Options{BindAddress: fmt.Sprintf("%s:%d", commonOpts.MetricAddress, commonOpts.MetricPort)},
-		LeaderElection:   commonOpts.ManagerLeaderElection,
-		LeaderElectionID: "rbac.crds.gocardless.com",
+		Scheme:                        scheme,
+		Metrics:                       metricsserver.Options{BindAddress: fmt.Sprintf("%s:%d", commonOpts.MetricAddress, commonOpts.MetricPort)},
+		LeaderElection:                commonOpts.ManagerLeaderElection,
+		LeaderElectionID:              "rbac.crds.gocardless.com",
+		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
 		app.Fatalf("failed to create manager: %v", err)

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -59,9 +59,10 @@ func main() {
 	defer cancel()
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Metrics:          metricsserver.Options{BindAddress: fmt.Sprintf("%s:%d", commonOpts.MetricAddress, commonOpts.MetricPort)},
-		LeaderElection:   commonOpts.ManagerLeaderElection,
-		LeaderElectionID: "vault.crds.gocardless.com",
+		Metrics:                       metricsserver.Options{BindAddress: fmt.Sprintf("%s:%d", commonOpts.MetricAddress, commonOpts.MetricPort)},
+		LeaderElection:                commonOpts.ManagerLeaderElection,
+		LeaderElectionID:              "vault.crds.gocardless.com",
+		LeaderElectionReleaseOnCancel: true,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port: 443,
 		}),

--- a/cmd/workloads-manager/main.go
+++ b/cmd/workloads-manager/main.go
@@ -84,10 +84,11 @@ func main() {
 	lifecycleRecorder := workloadsv1alpha1.NewLifecycleEventRecorder(*contextName, logger, publisher, idBuilder)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Metrics:          metricsserver.Options{BindAddress: fmt.Sprintf("%s:%d", commonOpts.MetricAddress, commonOpts.MetricPort)},
-		LeaderElection:   commonOpts.ManagerLeaderElection,
-		LeaderElectionID: "workloads.crds.gocardless.com",
-		Scheme:           scheme,
+		Metrics:                       metricsserver.Options{BindAddress: fmt.Sprintf("%s:%d", commonOpts.MetricAddress, commonOpts.MetricPort)},
+		LeaderElection:                commonOpts.ManagerLeaderElection,
+		LeaderElectionID:              "workloads.crds.gocardless.com",
+		LeaderElectionReleaseOnCancel: true,
+		Scheme:                        scheme,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port: 443,
 		}),

--- a/config/base/rbac/leader-election.yaml
+++ b/config/base/rbac/leader-election.yaml
@@ -30,3 +30,9 @@ rules:
       - events
     verbs:
       - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - "*"


### PR DESCRIPTION
We want to start using leader election, so that we can have multiple pods running, in order to serve webhooks reliably.

The functionality for this is already available, but there's some tweaks here to make it work.

Commits:

---

**Add leases RBAC to base config** 

controller-runtime has migrated to the native `lease` object some time
ago, but this was missing in the manifests.

Resolves this error:

```
1 leaderelection.go:332] error retrieving resource lock theatre-system/workloads.crds.gocardless.com: leases.coordination.k8s.io "workloads.crds.gocardless.com" is forbidden: User "system:serviceaccount:theatre-system:theatre-workloads-manager" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "theatre-system"
```


---

**Release leader election lease on shutdown** 

As per the documentation for this option, we can do this to speed up
lease transitions, given that in our codebase we only ever immediately
exit the process if the manager is cancelled.


---

**Remove dangerous targets from Makefile** 

There's no reason to have these around any longer.


---
