### PR TITLE
Add GitHub Actions workflow to build and publish Docker image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,51 @@
+---
+name: publish-image
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write  # Required for OIDC authentication to GCP
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/230821733166/locations/global/workloadIdentityPools/github-actions-oidc-pool/providers/github-actions-provider
+          service_account: github-actions-theatre@incident-io-cicd.iam.gserviceaccount.com
+          token_format: access_token
+          create_credentials_file: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: europe-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            europe-docker.pkg.dev/incident-io-container-images/incident-io/theatre:${{ github.sha }}
+            europe-docker.pkg.dev/incident-io-container-images/incident-io/theatre:latest
+          build-args: |
+            git_revision=${{ github.sha }}


### PR DESCRIPTION
Builds the Docker image on push to master and pushes it to Artifact Registry using Workload Identity Federation for keyless auth.